### PR TITLE
[ci test] use libudev on musl linux with libudev feature

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,8 @@ on:
         type: boolean
       extra_packages:
         type: string
+      install_musl_eudev:
+        type: boolean
       runs_on:
         default: ubuntu-latest
         type: string
@@ -57,6 +59,29 @@ jobs:
           sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
           sudo apt-get -qq update
           sudo apt-get -qq -y install build-essential curl git pkg-config ${{ inputs.extra_packages }}
+
+      - name: Build | install musl eudev
+        if: inputs.runs_on == 'ubuntu-latest' && inputs.install_musl_eudev
+        run: |
+          curl -sLO https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.0/x86_64/apk.static
+          mkdir -p /tmp/alpine-sysroot
+          cat >> ./repositories <<-EOF
+          	https://dl-cdn.alpinelinux.org/alpine/v3.18/main/
+          EOF
+          arch="${{inputs.target}}"
+          arch="${arch/-unknown-linux-musl}"
+          case "$arch" in
+            i*86) arch=x86 ;;
+          esac
+          ./apk.static add \
+            --root /tmp/alpine-sysroot \
+            --repositories-file ./repositories \
+            --allow-untrusted \
+            --no-cache \
+            --no-scripts \
+            --arch "$arch" \
+            eudev-dev
+          echo "PKG_CONFIG_SYSROOT_DIR_${{inputs.target}}=/tmp/alpine-sysroot" >> $GITHUB_ENV
 
       - name: Build | add mingw32 to path
         if: inputs.runs_on == 'windows-2019'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,6 +64,7 @@ jobs:
         if: inputs.runs_on == 'ubuntu-latest' && inputs.install_musl_eudev
         run: |
           curl -sLO https://gitlab.alpinelinux.org/api/v4/projects/5/packages/generic/v2.14.0/x86_64/apk.static
+          chmod +x ./apk.static
           mkdir -p /tmp/alpine-sysroot
           cat >> ./repositories <<-EOF
           	https://dl-cdn.alpinelinux.org/alpine/v3.18/main/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,7 @@ jobs:
     with:
       disable_tests: true
       extra_packages: gcc-aarch64-linux-gnu
+      install_musl_eudev: true
       target: aarch64-unknown-linux-musl
 
   arm-linux-androideabi:
@@ -147,7 +148,8 @@ jobs:
   i686-unknown-linux-musl:
     uses: ./.github/workflows/build.yaml
     with:
-      extra_packages: libudev-dev gcc-multilib
+      extra_packages: gcc-multilib
+      install_musl_eudev: true
       target: i686-unknown-linux-musl
 
   x86_64-apple-darwin:
@@ -184,6 +186,7 @@ jobs:
   x86_64-unknown-linux-musl:
     uses: ./.github/workflows/build.yaml
     with:
+      install_musl_eudev: true
       target: x86_64-unknown-linux-musl
 
   x86_64-unknown-netbsd:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = ">=1.3.1, <2.1.0"
 cfg-if = "1.0.0"
 nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 
-[target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 libudev = { version = "0.3.0", optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]

--- a/src/posix/enumerate.rs
+++ b/src/posix/enumerate.rs
@@ -1,6 +1,6 @@
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use nix::libc::{c_char, c_void};
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 use std::ffi::OsStr;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use std::ffi::{CStr, CString};
@@ -22,14 +22,14 @@ use IOKit_sys::*;
 use crate::SerialPortType;
 #[cfg(any(
     target_os = "ios",
-    all(target_os = "linux", not(target_env = "musl"), feature = "libudev"),
+    all(target_os = "linux", feature = "libudev"),
     target_os = "macos"
 ))]
 use crate::UsbPortInfo;
 #[cfg(any(
     target_os = "android",
     target_os = "ios",
-    all(target_os = "linux", not(target_env = "musl"), feature = "libudev"),
+    all(target_os = "linux", feature = "libudev"),
     target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
@@ -39,7 +39,7 @@ use crate::{Result, SerialPortInfo};
 
 /// Retrieves the udev property value named by `key`. If the value exists, then it will be
 /// converted to a String, otherwise None will be returned.
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 fn udev_property_as_string(d: &libudev::Device, key: &str) -> Option<String> {
     d.property_value(key)
         .and_then(OsStr::to_str)
@@ -52,7 +52,7 @@ fn udev_property_as_string(d: &libudev::Device, key: &str) -> Option<String> {
 /// will be returned.
 /// This function uses a built-in type's `from_str_radix` to implementation to perform the
 /// actual conversion.
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 fn udev_hex_property_as_int<T>(
     d: &libudev::Device,
     key: &str,
@@ -69,7 +69,7 @@ fn udev_hex_property_as_int<T>(
     }
 }
 
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 fn port_type(d: &libudev::Device) -> Result<SerialPortType> {
     match d.property_value("ID_BUS").and_then(OsStr::to_str) {
         Some("usb") => {
@@ -395,7 +395,7 @@ cfg_if! {
             }
             Ok(vec)
         }
-    } else if #[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))] {
+    } else if #[cfg(all(target_os = "linux", feature = "libudev"))] {
         /// Scans the system for serial ports and returns a list of them.
         /// The `SerialPortInfo` struct contains the name of the port
         /// which can be used for opening it.

--- a/src/posix/error.rs
+++ b/src/posix/error.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use crate::{Error, ErrorKind};
 
-#[cfg(all(target_os = "linux", not(target_env = "musl"), feature = "libudev"))]
+#[cfg(all(target_os = "linux", feature = "libudev"))]
 impl From<libudev::Error> for Error {
     fn from(e: libudev::Error) -> Error {
         use libudev::ErrorKind as K;

--- a/src/posix/ioctl.rs
+++ b/src/posix/ioctl.rs
@@ -51,11 +51,7 @@ mod raw {
             target_os = "android",
             all(
                 target_os = "linux",
-                not(any(
-                    target_env = "musl",
-                    target_arch = "powerpc",
-                    target_arch = "powerpc64"
-                ))
+                not(any(target_arch = "powerpc", target_arch = "powerpc64"))
             )
         ))]
         tcgets2,
@@ -68,11 +64,7 @@ mod raw {
             target_os = "android",
             all(
                 target_os = "linux",
-                not(any(
-                    target_env = "musl",
-                    target_arch = "powerpc",
-                    target_arch = "powerpc64"
-                ))
+                not(any(target_arch = "powerpc", target_arch = "powerpc64"))
             )
         ))]
         tcsets2,
@@ -167,11 +159,7 @@ pub fn tiocmbis(fd: RawFd, status: SerialLines) -> Result<()> {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub fn tcgets2(fd: RawFd) -> Result<libc::termios2> {
@@ -186,11 +174,7 @@ pub fn tcgets2(fd: RawFd) -> Result<libc::termios2> {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub fn tcsets2(fd: RawFd, options: &libc::termios2) -> Result<()> {

--- a/src/posix/termios.rs
+++ b/src/posix/termios.rs
@@ -17,7 +17,6 @@ cfg_if! {
         all(
             target_os = "linux",
             any(
-                target_env = "musl",
                 target_arch = "powerpc",
                 target_arch = "powerpc64"
             )
@@ -29,7 +28,6 @@ cfg_if! {
         all(
             target_os = "linux",
             not(any(
-                target_env = "musl",
                 target_arch = "powerpc",
                 target_arch = "powerpc64"
             ))
@@ -65,11 +63,7 @@ pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
     target_os = "openbsd",
     all(
         target_os = "linux",
-        any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        )
+        any(target_arch = "powerpc", target_arch = "powerpc64")
     )
 ))]
 pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
@@ -85,11 +79,7 @@ pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub(crate) fn get_termios(fd: RawFd) -> Result<Termios> {
@@ -117,11 +107,7 @@ pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios, baud_rate: u32) ->
     target_os = "openbsd",
     all(
         target_os = "linux",
-        any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        )
+        any(target_arch = "powerpc", target_arch = "powerpc64")
     )
 ))]
 pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios) -> Result<()> {
@@ -134,11 +120,7 @@ pub(crate) fn set_termios(fd: RawFd, termios: &libc::termios) -> Result<()> {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub(crate) fn set_termios(fd: RawFd, termios: &Termios) -> Result<()> {
@@ -206,11 +188,7 @@ pub(crate) fn set_stop_bits(termios: &mut Termios, stop_bits: StopBits) {
     target_os = "android",
     all(
         target_os = "linux",
-        not(any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        ))
+        not(any(target_arch = "powerpc", target_arch = "powerpc64"))
     )
 ))]
 pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) {
@@ -234,11 +212,7 @@ pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) {
 
 #[cfg(all(
     target_os = "linux",
-    any(
-        target_env = "musl",
-        target_arch = "powerpc",
-        target_arch = "powerpc64"
-    )
+    any(target_arch = "powerpc", target_arch = "powerpc64")
 ))]
 pub(crate) fn set_baud_rate(termios: &mut Termios, baud_rate: u32) {
     use self::libc::{

--- a/src/posix/tty.rs
+++ b/src/posix/tty.rs
@@ -446,11 +446,7 @@ impl SerialPort for TTYPort {
         target_os = "android",
         all(
             target_os = "linux",
-            not(any(
-                target_env = "musl",
-                target_arch = "powerpc",
-                target_arch = "powerpc64"
-            ))
+            not(any(target_arch = "powerpc", target_arch = "powerpc64"))
         )
     ))]
     fn baud_rate(&self) -> Result<u32> {
@@ -497,11 +493,7 @@ impl SerialPort for TTYPort {
     /// desired baud rate.
     #[cfg(all(
         target_os = "linux",
-        any(
-            target_env = "musl",
-            target_arch = "powerpc",
-            target_arch = "powerpc64"
-        )
+        any(target_arch = "powerpc", target_arch = "powerpc64")
     ))]
     fn baud_rate(&self) -> Result<u32> {
         use self::libc::{

--- a/tests/test_tty.rs
+++ b/tests/test_tty.rs
@@ -135,14 +135,7 @@ fn test_ttyport_set_standard_baud() {
 
 // On mac this fails because you can't set nonstandard baud rates for these virtual ports
 #[test]
-#[cfg_attr(
-    any(
-        target_os = "ios",
-        all(target_os = "linux", target_env = "musl"),
-        target_os = "macos"
-    ),
-    ignore
-)]
+#[cfg_attr(any(target_os = "ios", target_os = "macos"), ignore)]
 fn test_ttyport_set_nonstandard_baud() {
     // `master` must be used here as Dropping it causes slave to be deleted by the OS.
     // TODO: Convert this to a statement-level attribute once


### PR DESCRIPTION
udev is a typical way of handling devices on musl-based distributions as well. there is no reason to handle this differently than on gnu libc distros.